### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: false
     default: pkgcheck>=0.10.3
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
I [tested this](https://github.com/hololeap/gentoo-haskell/actions/runs/3726490532/jobs/6319971508) on a fork of [`gentoo-haskell`](https://github.com/gentoo-haskell/gentoo-haskell), and it seems to work.

Closes: https://github.com/pkgcore/pkgcheck-action/issues/7
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/