### PR TITLE
src: switch to Python 3.11 rather than Python 3.x for now

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -65936,7 +65936,7 @@ async function run() {
     // use vendored setup-python action
     // https://github.com/actions/setup-python/issues/38
     await core.group('Set up python', async () => {
-      const installed = await setupPython.findPythonVersion('3.x', 'x64');
+      const installed = await setupPython.findPythonVersion('3.11', 'x64');
       core.info(`Successfully set up ${installed.impl}-${installed.version}`);
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,8 @@ async function run() {
     // use vendored setup-python action
     // https://github.com/actions/setup-python/issues/38
     await core.group('Set up python', async () => {
-      const installed = await setupPython.findPythonVersion('3.x', 'x64');
+      // XXX: 3.11 is a temporary hack for https://github.com/pkgcore/pkgcheck-action/issues/13
+      const installed = await setupPython.findPythonVersion('3.11', 'x64');
       core.info(`Successfully set up ${installed.impl}-${installed.version}`);
     });
 


### PR DESCRIPTION
This is a workaround for Python 3.12 dropping distutils.

For a proper fix, we could either depend on setuptools still for the bundled copy of tree-sitter-bash (we allow using the system copy but the action doesn't use it) or port away from that too.

Fixes: https://github.com/pkgcore/pkgcheck-action/issues/13