### PR TITLE
add safe directory to git target

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
           runner() { echo \"::group::${1}\"; shift 1; \"$@\"; local exit=$?; echo; echo \"::endgroup::\"; return $exit; } ;
           runner \"Sync gentoo repo\" pmaint sync gentoo || exit 1 ;
           runner \"Update repo metadata\" pmaint regen --dir ~/.cache/pkgcheck/repos . ;
+          runner \"Marking workspace safe for git\" git config --global --add safe.directory ${{ github.workspace }} ;
           runner \"Run pkgcheck\" pkgcheck --color y ci --failures ~/failures.json --exit GentooCI ${{ inputs.args }} ;
           scan_exit_status=$? ;
           pkgcheck replay --color y ~/failures.json ;


### PR DESCRIPTION
pkgcheck uses git for some of it's checks, however, the github.workspace directory not being marked safe causes a failure

See also: https://github.com/actions/checkout/issues/1169
See also: https://github.com/pentoo/pentoo-overlay/actions/runs/7560749313/job/20587445443
Closes: https://github.com/pkgcore/pkgcheck-action/issues/18
Signed-off-by: Zero_Chaos <zerochaos@gentoo.org>