### PR TITLE
verbump actions/cache@4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Cache pkgcheck
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/pkgcore


### PR DESCRIPTION
build errors thown:

Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: actions/cache@v3.

For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.