### PR TITLE
Bump actions/* (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout pkgcheck-action
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: pkgcheck-action
 
     - name: Checkout GURU repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: gentoo/guru
         path: guru

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run pkgcheck
       uses: pkgcore/pkgcheck-action@v1
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run pkgcheck
       uses: pkgcore/pkgcheck-action@v1

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Cache pkgcheck
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/pkgcore


### PR DESCRIPTION
Node.js 20 actions are deprecated.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

See also:
https://github.com/actions/checkout (latest version v6)
https://github.com/actions/cache (latest version v5)